### PR TITLE
Update vlucas/phpdotenv version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/filesystem": "~2.7",
         "webmozart/path-util": "~1.0",
         "anahkiasen/underscore-php": "2.0.*",
-        "vlucas/phpdotenv": "1.0.*"
+        "vlucas/phpdotenv": "~1.0"
     },
     "require-dev": {
         "caffeinated/dev": "dev-master@dev"


### PR DESCRIPTION
Resolve problem with phpdotenv versions conflict. Example:

```
Using version ^6.0 for radic/blade-extensions         
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)         
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: don't install radic/blade-extensions 6.0.2
    - Conclusion: don't install radic/blade-extensions 6.0.1
    - Conclusion: remove vlucas/phpdotenv v1.1.1
    - Installation request for radic/blade-extensions ^6.0 -> satisfiable by radic/blade-extensions[6.0.0, 6.0.1, 6.0.2].
    - Conclusion: don't install vlucas/phpdotenv v1.1.1
    - radic/blade-extensions 6.0.0 requires caffeinated/beverage ~3.0 -> satisfiable by caffeinated/beverage[3.0.2, 3.0.1, 3.0.0].
    - caffeinated/beverage 3.0.0 requires vlucas/phpdotenv 1.0.* -> satisfiable by vlucas/phpdotenv[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, v1.0.8, v1.0.9].
    - caffeinated/beverage 3.0.1 requires vlucas/phpdotenv 1.0.* -> satisfiable by vlucas/phpdotenv[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, v1.0.8, v1.0.9].
    - caffeinated/beverage 3.0.2 requires vlucas/phpdotenv 1.0.* -> satisfiable by vlucas/phpdotenv[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, v1.0.8, v1.0.9].
    - caffeinated/beverage 3.0.2 requires vlucas/phpdotenv 1.0.* -> satisfiable by vlucas/phpdotenv[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, v1.0.8, v1.0.9].
    - caffeinated/beverage 3.0.1 requires vlucas/phpdotenv 1.0.* -> satisfiable by vlucas/phpdotenv[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, v1.0.8, v1.0.9].
    - caffeinated/beverage 3.0.0 requires vlucas/phpdotenv 1.0.* -> satisfiable by vlucas/phpdotenv[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, v1.0.8, v1.0.9].
    - Can only install one of: vlucas/phpdotenv[1.0.0, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[1.0.1, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[1.0.2, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[1.0.3, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[1.0.4, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[1.0.5, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[1.0.6, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[v1.0.8, v1.1.1].
    - Can only install one of: vlucas/phpdotenv[v1.0.9, v1.1.1].
    - Installation request for vlucas/phpdotenv == 1.1.1.0 -> satisfiable by vlucas/phpdotenv[v1.1.1].
```
